### PR TITLE
Fix a bug that vector transform is not translated.

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -16,8 +16,8 @@ type Vector4 = (f32, f32, f32, f32);
 impl Vector for Vector2 {
     fn transform(self, matrix: &Matrix) -> Self {
 
-        let x = self.0 * matrix[0][0] + self.1 * matrix[1][0];
-        let y = self.0 * matrix[0][1] + self.1 * matrix[1][1];
+        let x = self.0 * matrix[0][0] + self.1 * matrix[1][0] + matrix[3][0];
+        let y = self.0 * matrix[0][1] + self.1 * matrix[1][1] + matrix[3][1];
         (x, y)
     }
 
@@ -41,9 +41,9 @@ impl Vector for Vector2 {
 
 impl Vector for Vector3 {
     fn transform(self, matrix: &Matrix) -> Self {
-        let x = self.0 * matrix[0][0] + self.1 * matrix[1][0] + self.2 * matrix[2][0];
-        let y = self.0 * matrix[0][1] + self.1 * matrix[1][1] + self.2 * matrix[2][1];
-        let z = self.0 * matrix[0][2] + self.1 * matrix[1][2] + self.2 * matrix[2][2];
+        let x = self.0 * matrix[0][0] + self.1 * matrix[1][0] + self.2 * matrix[2][0] + matrix[3][0];
+        let y = self.0 * matrix[0][1] + self.1 * matrix[1][1] + self.2 * matrix[2][1] + matrix[3][1];
+        let z = self.0 * matrix[0][2] + self.1 * matrix[1][2] + self.2 * matrix[2][2] + matrix[3][2];
         (x, y, z)
     }
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -11,12 +11,12 @@ fn transform_vector2() {
         41.0, 43.0, 47.0, 53.0,
     );
 
-    let origin = (1.0, 1.0);
+    let origin = (100.0, 10000.0);
 
     let transformed = origin.transform(&matrix);
 
-    assert_eq!(transformed.0, 13.0);
-    assert_eq!(transformed.1, 16.0);
+    assert_eq!(transformed.0, 110241.0);
+    assert_eq!(transformed.1, 130343.0);
 }
 
 #[test]
@@ -28,13 +28,13 @@ fn transform_vector3() {
         41.0, 43.0, 47.0, 53.0,
     );
 
-    let origin = (1.0, 1.0, 1.0);
+    let origin = (100.0, 10000.0, 1000000.0);
 
     let transformed = origin.transform(&matrix);
 
-    assert_eq!(transformed.0, 36.0);
-    assert_eq!(transformed.1, 45.0);
-    assert_eq!(transformed.2, 53.0);
+    assert_eq!(transformed.0, 23110241.0);
+    assert_eq!(transformed.1, 29130343.0);
+    assert_eq!(transformed.2, 31170547.0);
 }
 
 #[test]
@@ -46,14 +46,14 @@ fn transform_vector4() {
         41.0, 43.0, 47.0, 53.0,
     );
 
-    let origin = (1.0, 1.0, 1.0, 1.0);
+    let origin = (1.0, 100.0, 10000.0, 1000000.0);
 
     let transformed = origin.transform(&matrix);
 
-    assert_eq!(transformed.0, 77.0);
-    assert_eq!(transformed.1, 88.0);
-    assert_eq!(transformed.2, 100.0);
-    assert_eq!(transformed.3, 116.0);
+    assert_eq!(transformed.0, 41231102.0);
+    assert_eq!(transformed.1, 43291303.0);
+    assert_eq!(transformed.2, 47311705.0);
+    assert_eq!(transformed.3, 53371907.0);
 }
 
 #[test]


### PR DESCRIPTION
XMVector2Transform and XMVector3Transform uses 3 row for translation. But
current xmath implementation ignores 3 row.

This patch makes transform function returns translated vector.
